### PR TITLE
feat: use internal assetId returned in the play response for analytics

### DIFF
--- a/src/main/java/com/redbeemedia/enigma/core/player/MockPlaybackStartAction.java
+++ b/src/main/java/com/redbeemedia/enigma/core/player/MockPlaybackStartAction.java
@@ -73,7 +73,7 @@ public class MockPlaybackStartAction implements IPlaybackStartAction {
         }
 
         @Override
-        public IPlaybackSessionInfo getPlaybackSessionInfo(String manifestUrl, String cdnProvider, String playbackSessionId) {
+        public IPlaybackSessionInfo getPlaybackSessionInfo(String assetId, String manifestUrl, String cdnProvider, String playbackSessionId) {
             return playbackSessionInfo;
         }
 


### PR DESCRIPTION
Linked to the other pull request for https://tools.cloud.ebms.ericsson.net/jira/browse/EMP-18707